### PR TITLE
Context functionality added, the form properly sends data to our cont…

### DIFF
--- a/src/components/ContextChild.js
+++ b/src/components/ContextChild.js
@@ -1,9 +1,18 @@
-import React from 'react'
+import React, { useContext } from 'react'
+import { ExampleContext } from './ContextComponent'
 
-const ContextChild = (props) => {
+const ContextChild = () => {
+    const { exampleState } = useContext(ExampleContext)
     return ( 
-        // This child will take the context state and map over it or I'll just use the first index like I did with the other examples. Likely I'll map it so I can test it with multiple submissions.
-        <h1>Placeholder</h1>
+        <div>
+            {exampleState.examples.map(item => (
+                <div key={item.id}>
+                    <h1>{item.name}</h1>
+                    <h3>{item.description}</h3>
+                    <p>Arbitrary number --{">"} {item.number}</p>
+                </div>
+            ))}
+        </div>
      );
 }
  

--- a/src/components/ContextComponent.js
+++ b/src/components/ContextComponent.js
@@ -1,16 +1,32 @@
-import React from 'react'
+import React, { useState, createContext } from 'react'
 import ContextChild from './ContextChild'
 import TempForm from './TempForm'
 import { Route, Link } from 'react-router-dom'
 import App from '../App'
 
-const ContextComponent = (props) => {
+export const ExampleContext = createContext()
+
+const ContextComponent = () => {
+    const initValues = {
+        examples: [
+            {
+            name: "Default Example",
+            description: "Description of default example.",
+            number: 1,
+            id: 1
+            }
+        ]
+    }
+    const [exampleState, setExampleState] = useState(initValues)
+
     return ( 
         <div>
-            <Link to="/">Home</Link>
-            <Route exact path="/" component={App} />
-            <TempForm />
-            <ContextChild />
+            <ExampleContext.Provider value={{exampleState, setExampleState}}>
+                <Link to="/">Home</Link>
+                <Route exact path="/" component={App} />
+                <TempForm />
+                {exampleState.examples.length > 0 && <ContextChild />}
+            </ExampleContext.Provider>  
         </div>
      );
 }

--- a/src/components/TempForm.js
+++ b/src/components/TempForm.js
@@ -1,6 +1,9 @@
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
+import { ExampleContext } from './ContextComponent'
 
-const TempForm = (props) => {
+const TempForm = () => {
+    const { exampleState, setExampleState } = useContext(ExampleContext)
+
     const initValues = {
         name: "",
         description: "",
@@ -17,7 +20,10 @@ const TempForm = (props) => {
     }
     const handleSubmit = evt => {
         evt.preventDefault()
-        //push to context state
+        setExampleState({
+            ...exampleState,
+            examples: [...exampleState.examples, formState]
+        })
         setFormState(initValues)
     }
 


### PR DESCRIPTION
…ext state and the context child renders it. Since context api allows props to be sent as normal within childs of its provider I don't feel it necessary to create an additional child and send it props in that manner; I would rather have two examples of its consumation use. The next step is, likely, to setup an api request to a free api using thunk. After that, probably some form validation using up. After all, creating a testing suite and creating tests to run.